### PR TITLE
Remove prosemirror-schema-basic dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "prosemirror-inputrules": "^0.11.0",
-    "prosemirror-schema-basic": "^0.11.0",
     "prosemirror-schema-list": "^0.11.0",
     "prosemirror-schema-table": "^0.11.0",
     "prosemirror-keymap": "^0.11.0",


### PR DESCRIPTION
I was trying to setup an installation of prosemirror without using the
`prosemirror-schema-basic` module and `npm install` errored out due to
not being able to access the `prosemirror-schema-basic` module. I
couldn't find a place that `prosemirror-example-setup` actually uses
the `prosemirror-schema-basic`, so this commit removes the unused
dependency from the `package.json` file.
