### PR TITLE
fix buttons display

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -28,6 +28,14 @@
   cursor: default;
 }
 
+.ProseMirror-menu-dropdown-wrap {
+  display: inline-block;
+}
+
+.ProseMirror-icon svg {
+  height: 1em;
+}
+
 .ProseMirror-prompt {
   background: white;
   padding: 5px 10px 5px 15px;


### PR DESCRIPTION
I have a problems following the guide from [here](https://prosemirror.net/examples/basic/) with styles imported from `prosemirror-example-setup`.
Full code below:
```typescript
import '../node_modules/prosemirror-example-setup/style/style.css'

import { EditorState } from "prosemirror-state";
import { EditorView } from "prosemirror-view";
import { Schema, DOMParser } from "prosemirror-model";
import { schema } from "prosemirror-schema-basic";
import { addListNodes } from "prosemirror-schema-list"
import { exampleSetup } from "prosemirror-example-setup";

import type { EditorStateConfig } from 'prosemirror-state';

// Mix the nodes from prosemirror-schema-list into the basic schema to
// create a schema with list support.
const mySchema = new Schema({
  nodes: addListNodes(schema.spec.nodes, "paragraph block*", "block"),
  marks: schema.spec.marks
});


// editor config
let editorStateConfig: EditorStateConfig = {
  plugins: exampleSetup({ schema: mySchema })
};

const initialContent = document.querySelector("#content");
if (initialContent) {
  editorStateConfig.doc = DOMParser.fromSchema(mySchema).parse(initialContent);
}

// editor state
let editorState = EditorState.create(editorStateConfig);


// editor view
new EditorView(document.querySelector<HTMLDivElement>('#editor'), {
  state: editorState
});
```
That is resulted to me as shown on screenshot below:
<img width="283" height="417" alt="proseMirror-example-setup" src="https://github.com/user-attachments/assets/7b4d5fb2-4429-4047-b708-3f85284d3495" />

After my fix buttons are displayed okay:
<img width="398" height="117" alt="image" src="https://github.com/user-attachments/assets/fe591eef-871e-43b6-a28c-d07e72ab12d7" />
